### PR TITLE
Add fn diff/3 which returns a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ end
 ## Quick example
 
 ```elixir
+> Exdiff.diff("abd", "abcd")
+%{html: "<div class='exdiff-eq'>ab</div><div class='exdiff-ins'>c</div><div class='exdiff-eq'>d</div>", length: 1}
+
+> Exdiff.diff("abd", "abcd", wrapper_tag: "span")
+%{html: "<span class='exdiff-eq'>ab</span><span class='exdiff-ins'>c</span><span class='exdiff-eq'>d</span>", length: 1}
+
 > Exdiff.diff_to_html("abd", "abcd")
 {1, "<div class='exdiff-eq'>ab</div><div class='exdiff-ins'>c</div><div class='exdiff-eq'>d</div>"}
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add `exdiff` to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:exdiff, "~> 0.1.4"}]
+  [{:exdiff, "~> 0.1.5"}]
 end
 ```
 

--- a/lib/exdiff.ex
+++ b/lib/exdiff.ex
@@ -2,8 +2,8 @@ defmodule Exdiff do
   @moduledoc """
     Exdiff is a simple wrapper to make String.myers_difference/2 useful.
   """
-  
-  def diff_to_html(string1, string2, opts \\ []) do
+
+  def diff(string1, string2, opts \\ []) do
     separator = Keyword.get(opts, :separator, "")
     wrapper_tag = Keyword.get(opts, :wrapper_tag, "div")
 
@@ -22,7 +22,12 @@ defmodule Exdiff do
         end)
       |> elem(1)
     diff_count = Keyword.get(diffs_count, :ins, 0) - Keyword.get(diffs_count, :del, 0)
-    {diff_count, html}
+    %{html: html, length: diff_count}
+  end
+  
+  def diff_to_html(string1, string2, opts \\ []) do
+    diff_map = diff(string1, string2, opts)
+    {diff_map.length, diff_map.html}
   end
   
   defp wrap_html(lmd, wrapper_tag) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Exdiff.Mixfile do
   def project do
     [
       app: :exdiff,
-      version: "0.1.4",
+      version: "0.1.5",
       elixir: "~> 1.5",
       package: package(),
       name: "Exdiff",

--- a/test/exdiff_test.exs
+++ b/test/exdiff_test.exs
@@ -3,6 +3,31 @@ defmodule ExdiffTest do
 
   doctest Exdiff
 
+  describe "Exdiff.diff/3" do
+    test "accept nil as a parameter" do
+      assert Exdiff.diff(nil, "a") == %{html: "<div class='exdiff-ins'>a</div>", length: 1}
+      assert Exdiff.diff("a", nil) == %{html: "<div class='exdiff-del'>a</div>", length: -1}
+      assert Exdiff.diff(nil, nil) == %{html: "", length: 0}
+    end
+    
+    test "compare and return diff with a separator." do
+      str_a = "<p>abc</p>"
+      str_b = "<p>abc</p><p>def</p>"
+      diff_count = String.length(str_b) - String.length(str_a)
+      assert Exdiff.diff(str_a, str_b, separator: "</p>") == %{html: "<div class='exdiff-eq'><p>abc</p></div><div class='exdiff-ins'><p>def</p></div>", length: diff_count}
+      assert Exdiff.diff(str_b, str_a, separator: "</p>") == %{html: "<div class='exdiff-eq'><p>abc</p></div><div class='exdiff-del'><p>def</p></div>", length: -diff_count}
+      assert Exdiff.diff(str_a, str_a, separator: "</p>") == %{html: "<div class='exdiff-eq'><p>abc</p></div>", length: 0}
+    end
+
+    test "accepts a custom wrapper tag optionally" do
+      str_a = "Hello Exdiff."
+      str_b = "Hi Exdiff."
+      diff_count = String.length(str_b) - String.length(str_a)
+      assert Exdiff.diff(str_a, str_b, wrapper_tag: "span") ==
+        %{html: "<span class='exdiff-eq'>H</span><span class='exdiff-del'>ello</span><span class='exdiff-ins'>i</span><span class='exdiff-eq'> Exdiff.</span>", length: diff_count}
+    end
+  end
+
   describe "Exdff.diff_to_html/2" do
     test "may accept nil as a parameter" do
       assert Exdiff.diff_to_html(nil, "a") == {1, "<div class='exdiff-ins'>a</div>"}


### PR DESCRIPTION
Add function `diff/3` which uses map as a return type.

Currently two key-value pairs are included; `:html` and `:length`.

This solves the issue #5.